### PR TITLE
DEV: Delete old data from oauth2_user_infos table

### DIFF
--- a/db/post_migrate/20211230152530_remove_old_linkedin_data.rb
+++ b/db/post_migrate/20211230152530_remove_old_linkedin_data.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+class RemoveOldLinkedinData < ActiveRecord::Migration[6.1]
+  def up
+    execute "DELETE FROM oauth2_user_infos WHERE provider = 'linkedin'"
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
This was migrated to `user_associated_accounts` in caeac62a