### PR TITLE
DEV: Explicitly define primary_email_verified? method for LinkedIn authenticators

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -31,6 +31,13 @@ class ::LinkedInAuthenticator < ::Auth::ManagedAuthenticator
   def enabled?
     SiteSetting.linkedin_enabled
   end
+
+  # linkedin doesn't let users login with OAuth2 to websites unless they verify
+  # their email address so whatever email we get from linkedin has to be
+  # verified
+  def primary_email_verified?(auth_token)
+    true
+  end
 end
 
 auth_provider authenticator: ::LinkedInAuthenticator.new,


### PR DESCRIPTION
Related core PR: https://github.com/discourse/discourse/pull/19127.

Internal topic: t/82084.