### PR TITLE
DEV: Deprecate LinkedIn Auth plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ⚠️ This plugin is no longer supported
 
+See [Configure LinkedIn OpenID Connect login for Discourse](https://meta.discourse.org/t/configure-linkedin-openid-connect-login-for-discourse/305366).
+
 # LinkedIn OAuth Login Plugin
 This plugin adds support logging in via LinkedIn.
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# ⚠️ This plugin is no longer supported
+
 # LinkedIn OAuth Login Plugin
 This plugin adds support logging in via LinkedIn.
 

--- a/app/services/problem_check/deprecated_linkedin_auth.rb
+++ b/app/services/problem_check/deprecated_linkedin_auth.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class ProblemCheck::DeprecatedLinkedInAuth < ProblemCheck
+  self.priority = "high"
+
+  def call
+    return no_problem if !SiteSetting.linkedin_enabled
+
+    problem
+  end
+
+  private
+
+  def message
+    "The discourse-linkedin-auth plugin is no longer supported, and LinkedIn OpenID Connect support has been added to Discourse core. You are recommended to update the authentication method in your LinkedIn app. Please see <a href='https://meta.discourse.org/t/discourse-linkedin-authentication/46818'>https://meta.discourse.org/t/discourse-linkedin-authentication/46818</a> for more information."
+  end
+end

--- a/plugin.rb
+++ b/plugin.rb
@@ -20,7 +20,9 @@ require_relative "lib/linked_in_authenticator"
 auth_provider authenticator: ::LinkedInAuthenticator.new, icon: "fab-linkedin"
 
 after_initialize do
-  AdminDashboardData.add_problem_check do
-    "The discourse-linkedin-auth plugin is no longer supported, and LinkedIn OpenID Connect support has been added to Discourse core. You are recommended to update the authentication method in your LinkedIn app. Please see https://meta.discourse.org/t/discourse-linkedin-authentication/46818 for more information."
+  if SiteSetting.linkedin_enabled
+    AdminDashboardData.add_problem_check do
+      "The discourse-linkedin-auth plugin is no longer supported, and LinkedIn OpenID Connect support has been added to Discourse core. You are recommended to update the authentication method in your LinkedIn app. Please see https://meta.discourse.org/t/discourse-linkedin-authentication/46818 for more information."
+    end
   end
 end

--- a/plugin.rb
+++ b/plugin.rb
@@ -20,9 +20,7 @@ require_relative "lib/linked_in_authenticator"
 auth_provider authenticator: ::LinkedInAuthenticator.new, icon: "fab-linkedin"
 
 after_initialize do
-  if SiteSetting.linkedin_enabled
-    AdminDashboardData.add_problem_check do
-      "The discourse-linkedin-auth plugin is no longer supported, and LinkedIn OpenID Connect support has been added to Discourse core. You are recommended to update the authentication method in your LinkedIn app. Please see https://meta.discourse.org/t/discourse-linkedin-authentication/46818 for more information."
-    end
-  end
+  require_relative "app/services/problem_check/deprecated_linkedin_auth"
+
+  register_problem_check ProblemCheck::DeprecatedLinkedInAuth
 end

--- a/plugin.rb
+++ b/plugin.rb
@@ -18,3 +18,9 @@ enabled_site_setting :linkedin_enabled
 require_relative "lib/linked_in_authenticator"
 
 auth_provider authenticator: ::LinkedInAuthenticator.new, icon: "fab-linkedin"
+
+after_initialize do
+  AdminDashboardData.add_problem_check do
+    "The discourse-linkedin-auth plugin is no longer supported, and LinkedIn OpenID Connect support has been added to Discourse core. You are recommended to update the authentication method in your LinkedIn app. Please see https://meta.discourse.org/t/discourse-linkedin-authentication/46818 for more information."
+  end
+end


### PR DESCRIPTION
### Why is this being deprecated?

LinkedIn has stopped supporting its "vanilla" OAuth 2.0 authentication method. New apps can only use the new OpenID Connect authentication method.

We have now implemented LinkedIn OIDC authentication in core. LinkedIn has grandfathered the old authentication method,  which this plugin serves, so we recommend upgrading to the new one in the deprecation message.

<img width="1086" alt="Screenshot 2024-04-25 at 1 45 15 PM" src="https://github.com/discourse/discourse-linkedin-auth/assets/5259935/c7f55738-e3fa-4f9e-8e8e-3b88c04ff37c">