### PR TITLE
FIX: Add deprecated plugin problem check translation

### DIFF
--- a/app/services/problem_check/deprecated_linkedin_auth.rb
+++ b/app/services/problem_check/deprecated_linkedin_auth.rb
@@ -8,10 +8,4 @@ class ProblemCheck::DeprecatedLinkedInAuth < ProblemCheck
 
     problem
   end
-
-  private
-
-  def message
-    "The discourse-linkedin-auth plugin is no longer supported, and LinkedIn OpenID Connect support has been added to Discourse core. You are recommended to update the authentication method in your LinkedIn app. Please see <a href='https://meta.discourse.org/t/discourse-linkedin-authentication/46818'>https://meta.discourse.org/t/discourse-linkedin-authentication/46818</a> for more information."
-  end
 end

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1,4 +1,7 @@
 en:
+  dashboard:
+    problem:
+      deprecated_linked_in_auth: "The discourse-linkedin-auth plugin is no longer supported, and LinkedIn OpenID Connect support has been added to Discourse core. You are recommended to update the authentication method in your LinkedIn app. Please see <a href='https://meta.discourse.org/t/discourse-linkedin-authentication/46818'>https://meta.discourse.org/t/discourse-linkedin-authentication/46818</a> for more information."
   site_settings:
     linkedin_enabled: 'Allow users to authenticate using LinkedIn?'
     linkedin_client_id: 'LinkedIn Client ID (need one? visit <a href="https://developer.linkedin.com/docs/oauth2">https://developer.linkedin.com/docs/oauth2</a>)'

--- a/spec/services/problem_check/deprecated_linkedin_auth_spec.rb
+++ b/spec/services/problem_check/deprecated_linkedin_auth_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+RSpec.describe ProblemCheck::DeprecatedLinkedInAuth do
+  subject(:check) { described_class.new }
+
+  describe ".call" do
+    before { SiteSetting.stubs(linkedin_enabled: enabled) }
+
+    context "when GitHub authentication is disabled" do
+      let(:enabled) { false }
+
+      it { expect(check).to be_chill_about_it }
+    end
+
+    context "when plugin is enabled" do
+      let(:enabled) { true }
+
+      it do
+        expect(check).to have_a_problem.with_priority("high").with_message(
+          "The discourse-linkedin-auth plugin is no longer supported, and LinkedIn OpenID Connect support has been added to Discourse core. You are recommended to update the authentication method in your LinkedIn app. Please see <a href='https://meta.discourse.org/t/discourse-linkedin-authentication/46818'>https://meta.discourse.org/t/discourse-linkedin-authentication/46818</a> for more information.",
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What is this fix?

We had a hard-coded problem check message using the `#message` method. We removed support from this in core, so the translation is now showing as missing.

This fixes that by moving the translation to the locale file, and adds a test for it.